### PR TITLE
Add syntax highlighting to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Complete documentation at GoDoc: [https://godoc.org/github.com/dchenk/go-render-
 
 ## Usage
 
-```
+```go
 import "github.com/dchenk/go-render-quill"
 
 var delta = `[{"insert":"This "},{"attributes":{"italic":true},"insert":"is"},


### PR DESCRIPTION
Just a small thingy to make it look nicer. Thanks for the package!