### PR TITLE
allow map-based embeds

### DIFF
--- a/raw_op.go
+++ b/raw_op.go
@@ -34,6 +34,7 @@ func (ro *rawOp) makeOp(o *Op) error {
 		for mk := range ins {
 			o.Type = mk
 			o.Data = extractString(ins[mk])
+			o.DataMap = extractMap(ins[mk])
 			break
 		}
 	default:
@@ -68,4 +69,20 @@ func extractString(v interface{}) string {
 		return strconv.FormatFloat(val, 'f', 0, 64)
 	}
 	return ""
+}
+
+func extractMap(v interface{}) map[string]string {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		newMap := make(map[string]string)
+		for key, value := range val {
+			if strValue, ok := value.(string); ok {
+				newMap[key] = strValue
+			} else {
+				newMap[key] = fmt.Sprint(value)
+			}
+		}
+		return newMap
+	}
+	return make(map[string]string)
 }

--- a/render.go
+++ b/render.go
@@ -133,9 +133,10 @@ func (o *Op) addFmTer(vars *renderVars, fmTer Formatter) {
 // An Op is a Delta insert operations (https://github.com/quilljs/delta#insert) that has been converted into this format for
 // usability with the type safety in Go.
 type Op struct {
-	Data  string            // the text to insert or the value of the embed object (http://quilljs.com/docs/delta/#embeds)
-	Type  string            // the type of the op (typically "text", but any other type can be registered)
-	Attrs map[string]string // key is attribute name; value is either the attribute value or "y" (meaning true)
+	Data    string // the text to insert or the value of the embed object (http://quilljs.com/docs/delta/#embeds)
+	DataMap map[string]string
+	Type    string            // the type of the op (typically "text", but any other type can be registered)
+	Attrs   map[string]string // key is attribute name; value is either the attribute value or "y" (meaning true)
 }
 
 // writeBlock writes a block element (which may be nested inside another block element if it is a FormatWrapper).
@@ -393,7 +394,7 @@ type Format struct {
 
 // A blankOp can be used to signal any FormatWrapper formats to write the final closing wrap.
 func blankOp() *Op {
-	return &Op{"", "text", make(map[string]string)}
+	return &Op{"", make(map[string]string), "text", make(map[string]string)}
 }
 
 // If cl has something, then classesList returns the class attribute to add to an HTML element with a space before the

--- a/render.go
+++ b/render.go
@@ -36,6 +36,9 @@ func RenderExtended(ops []byte, customFormats func(string, *Op) Formatter) ([]by
 		o:   Op{Attrs: make(map[string]string, 3)},
 	}
 
+	raw = append(raw, rawOp{
+		Insert: "\n",
+	})
 	for i := range raw {
 
 		if err := raw[i].makeOp(&vars.o); err != nil {


### PR DESCRIPTION
Delta format allows embeds in form of the map:
```
insert: {blotname: {attr: value}}
```

This PR adds support for it.